### PR TITLE
Exclude files and folders from check context cross-references

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ _Note: Official documentation for contexted library is [available on hexdocs][he
   - [Dividing each context into smaller parts](#dividing-each-context-into-smaller-parts)
     - [Being able to access docs and specs in auto-delegated functions](#being-able-to-access-docs-and-specs-in-auto-delegated-functions)
   - [Don't repeat yourself with CRUD operations](#dont-repeat-yourself-with-crud-operations)
+  - [Exclude files and folders from check context cross-references](#exclude-files-and-folders-from-check-context-cross-references)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -236,6 +237,17 @@ iex> App.Accounts.Users.__info__(:functions)
 ```
 
 Read more about `Contexted.CRUD` and its options in [docs](https://hexdocs.pm/contexted/Contexted.CRUD.html).
+
+<br/>
+
+### Exclude files and folders from check context cross-references
+
+Inside your `config.exs` you can add list of files and folders to exclude from checking context cross-references:
+
+```elixir
+config :contexted,
+  exclude: ["app/test", "app/lib/app/account.ex"]
+```
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ _Note: Official documentation for contexted library is [available on hexdocs][he
 - [Installation](#installation)
 - [Step by step overview](#step-by-step-overview)
   - [Keep contexts separate](#keep-contexts-separate)
+    - [Exclude files and folders from check context cross-references](#exclude-files-and-folders-from-check-context-cross-references)
   - [Dividing each context into smaller parts](#dividing-each-context-into-smaller-parts)
     - [Being able to access docs and specs in auto-delegated functions](#being-able-to-access-docs-and-specs-in-auto-delegated-functions)
-    - [Exclude files and folders from check context cross-references](#exclude-files-and-folders-from-check-context-cross-references)
   - [Don't repeat yourself with CRUD operations](#dont-repeat-yourself-with-crud-operations)
 - [Contributing](#contributing)
 - [License](#license)
@@ -104,7 +104,7 @@ def project do
 end
 ```
 
-Next, define a list of contexts available in the app inside _config.exs_:
+Next, define a list of contexts available in the app inside config file:
 
 ```elixir
 config :contexted, contexts: [
@@ -121,6 +121,17 @@ And that's it. From now on, whenever you will cross-reference one context with a
 ```
 
 Read more about `Contexted.Tracer` and its options in [docs](https://hexdocs.pm/contexted/Contexted.Tracer.html).
+
+<br/>
+
+#### Exclude files and folders from check context cross-references
+
+In special cases, you may need to exclude certain folders or files from cross-reference checks due to project structure or naming conventions. To do this, add a list of exclusions in config `exclude_paths` option:
+
+```elixir
+config :contexted,
+  exclude_paths: ["app/test"]
+```
 
 <br/>
 
@@ -196,17 +207,6 @@ config :contexted,
 You may also want to enable it only for certain environments, like `dev`.
 
 Read more about `Contexted.Delegator` and its options in [docs](https://hexdocs.pm/contexted/Contexted.Delegator.html).
-
-<br/>
-
-#### Exclude files and folders from check context cross-references
-
-Inside your `config.exs` you can add list of files and folders to exclude from checking context cross-references:
-
-```elixir
-config :contexted,
-  exclude_paths: ["app/test", "app/lib/app/account.ex"]
-```
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ _Note: Official documentation for contexted library is [available on hexdocs][he
   - [Keep contexts separate](#keep-contexts-separate)
   - [Dividing each context into smaller parts](#dividing-each-context-into-smaller-parts)
     - [Being able to access docs and specs in auto-delegated functions](#being-able-to-access-docs-and-specs-in-auto-delegated-functions)
+    - [Exclude files and folders from check context cross-references](#exclude-files-and-folders-from-check-context-cross-references)
   - [Don't repeat yourself with CRUD operations](#dont-repeat-yourself-with-crud-operations)
-  - [Exclude files and folders from check context cross-references](#exclude-files-and-folders-from-check-context-cross-references)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -199,6 +199,17 @@ Read more about `Contexted.Delegator` and its options in [docs](https://hexdocs.
 
 <br/>
 
+#### Exclude files and folders from check context cross-references
+
+Inside your `config.exs` you can add list of files and folders to exclude from checking context cross-references:
+
+```elixir
+config :contexted,
+  exclude_paths: ["app/test", "app/lib/app/account.ex"]
+```
+
+<br/>
+
 ### Don't repeat yourself with CRUD operations
 
 In most web apps CRUD operations are very common. Most of these, have the same pattern. Why not autogenerate them?
@@ -237,17 +248,6 @@ iex> App.Accounts.Users.__info__(:functions)
 ```
 
 Read more about `Contexted.CRUD` and its options in [docs](https://hexdocs.pm/contexted/Contexted.CRUD.html).
-
-<br/>
-
-### Exclude files and folders from check context cross-references
-
-Inside your `config.exs` you can add list of files and folders to exclude from checking context cross-references:
-
-```elixir
-config :contexted,
-  exclude_paths: ["app/test", "app/lib/app/account.ex"]
-```
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Inside your `config.exs` you can add list of files and folders to exclude from c
 
 ```elixir
 config :contexted,
-  exclude: ["app/test", "app/lib/app/account.ex"]
+  exclude_paths: ["app/test", "app/lib/app/account.ex"]
 ```
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Add the following to your `mix.exs` file:
 ```elixir
 defp deps do
   [
-    {:contexted, "~> 0.1.11"}
+    {:contexted, "~> 0.2.0"}
   ]
 end
 ```

--- a/lib/contexted/tracer.ex
+++ b/lib/contexted/tracer.ex
@@ -6,7 +6,7 @@ defmodule Contexted.Tracer do
   """
 
   @contexts Application.compile_env(:contexted, :contexts, [])
-  @exclude Application.compile_env(:contexted, :exclude, [])
+  @exclude_paths Application.compile_env(:contexted, :exclude_paths, [])
 
   @doc """
   Trace events are emitted during compilation.
@@ -108,7 +108,7 @@ defmodule Contexted.Tracer do
   @spec is_file_excluded_from_check?(String.t()) :: boolean()
   defp is_file_excluded_from_check?(file) do
     Enum.any?(
-      @exclude,
+      @exclude_paths,
       &String.contains?(file, &1)
     )
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Contexted.MixProject do
       app: :contexted,
       description:
         "Contexted is an Elixir library designed to streamline the management of complex Phoenix contexts in your projects, offering tools for module separation, subcontext creation, and auto-generating CRUD operations for improved code maintainability.",
-      version: "0.1.11",
+      version: "0.2.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
By adding new flag `exclude_paths` in config you can exclude files and folders from checking context cross-references. 

```elixir
config :contexted,
  exclude_paths: ["app/test", "app/lib/app/account.ex"]
```