### PR TITLE
Changes implementation of how beam folder path is fetched in Tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,11 @@ App.Account.find_user(1)
 
 Both docs and specs are attached as metadata of module once it's compiled and saved as `.beam`. In reference to the example of `App.Account` context, it's possible that `App.Account.Users` will not be saved in `.beam` file before the `delegate_all` macro is executed. Therefore, first, all of the modules have to be compiled, and saved to `.beam` and only then we can create `@doc` and `@spec` of each delegated function.
 
-As a workaround, in `Contexted.Tracer.after_compiler/1` all of the contexts `.beam` files are first deleted and then recompiled. This is an opt-in functionality, as it extends compilation time. If you want to enable it, set the following config value:
+As a workaround, in `Contexted.Tracer.after_compiler/1` all of the contexts `.beam` files are first deleted and then recompiled. This is an opt-in functionality, as it extends compilation time. If you want to enable it, set the following config values:
 
 ```elixir
 config :contexted,
+  app: :your_app_name, # replace 'your_app_name' with your real app name
   enable_recompilation: true
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Add the following to your `mix.exs` file:
 ```elixir
 defp deps do
   [
-    {:contexted, "~> 0.3.2"}
+    {:contexted, "~> 0.3.3"}
   ]
 end
 ```

--- a/lib/contexted/tracer.ex
+++ b/lib/contexted/tracer.ex
@@ -41,22 +41,22 @@ defmodule Contexted.Tracer do
   """
   @spec after_compiler(tuple()) :: tuple()
   def after_compiler({status, diagnostics}) do
-    beam_files_folder = extract_beam_files_folder()
     file_paths = remove_context_beams_and_return_module_paths()
+    beam_folder = get_beam_files_folder_path()
 
     silence_recompilation_warnings(fn ->
-      Kernel.ParallelCompiler.compile_to_path(file_paths, beam_files_folder)
+      Kernel.ParallelCompiler.compile_to_path(file_paths, beam_folder)
     end)
 
     {status, diagnostics}
   end
 
-  @spec extract_beam_files_folder :: String.t()
-  defp extract_beam_files_folder do
-    first_context = Utils.get_config_contexts() |> List.first()
-    compiled_file_path = :code.which(first_context) |> List.to_string()
-    compiled_file_name = Path.basename(compiled_file_path)
-    String.replace(compiled_file_path, compiled_file_name, "")
+  @spec get_beam_files_folder_path() :: String.t()
+  def get_beam_files_folder_path() do
+    build_sub_path = Mix.Project.build_path()
+    app_sub_path = Utils.get_config_app() |> Atom.to_string()
+
+    Path.join([build_sub_path, "lib", app_sub_path, "ebin"])
   end
 
   @spec remove_context_beams_and_return_module_paths :: list(String.t())

--- a/lib/contexted/tracer.ex
+++ b/lib/contexted/tracer.ex
@@ -52,7 +52,7 @@ defmodule Contexted.Tracer do
   end
 
   @spec get_beam_files_folder_path() :: String.t()
-  def get_beam_files_folder_path() do
+  def get_beam_files_folder_path do
     build_sub_path = Mix.Project.build_path()
     app_sub_path = Utils.get_config_app() |> Atom.to_string()
 

--- a/lib/contexted/utils.ex
+++ b/lib/contexted/utils.ex
@@ -7,7 +7,8 @@ defmodule Contexted.Utils do
   Checks is `enable_recompilation` option is set.
   """
   @spec recompilation_enabled? :: boolean()
-  def recompilation_enabled?, do: get_from_config(:enable_recompilation, false)
+  def recompilation_enabled?,
+    do: get_from_config(:enable_recompilation, false) && get_from_config(:app, false)
 
   @doc """
   Returns `contexts` option value from contexted config or `[]` if it's not set.
@@ -20,6 +21,9 @@ defmodule Contexted.Utils do
   """
   @spec get_config_exclude_paths :: list(String.t())
   def get_config_exclude_paths, do: get_from_config(:exclude_paths, [])
+
+  @spec get_config_app :: :atom
+  def get_config_app, do: get_from_config(:app, nil)
 
   @spec get_from_config(atom(), any()) :: any()
   defp get_from_config(option_name, default_value) do

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Contexted.MixProject do
       app: :contexted,
       description:
         "Contexted is an Elixir library designed to streamline the management of complex Phoenix contexts in your projects, offering tools for module separation, subcontext creation, and auto-generating CRUD operations for improved code maintainability.",
-      version: "0.3.2",
+      version: "0.3.3",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Some applications report errors from a function that fetches the beam folder path.

The current implementation extracts the beam folder path this way:
```elixir
first_context = Utils.get_config_contexts() |> List.first()
compiled_file_path = :code.which(first_context) |> List.to_string()
```

Reported errors appear to have the same root cause:
```
** (FunctionClauseError) no function clause matching in List.to_string/1    
    
    The following arguments were given to List.to_string/1:
    
        # 1
        :non_existing
    
    Attempted function clauses (showing 1 out of 1):
    
        def to_string(list) when is_list(list)
    
    (elixir 1.17.2) lib/list.ex:1079: List.to_string/1
    (contexted 0.3.2) lib/contexted/tracer.ex:57: 
```

The fix proposed in this PR constructs the BEAM folder path independently of any application module.
```elixir
  @spec get_beam_files_folder_path() :: String.t()
  def get_beam_files_folder_path() do
    build_sub_path = Mix.Project.build_path()
    app_sub_path = Utils.get_config_app() |> Atom.to_string()

    Path.join([build_sub_path, "lib", app_sub_path, "ebin"])
  end
```

