### PR TITLE
add support for context_options: warn instead of error, and specify allowed couplings

### DIFF
--- a/lib/contexted/utils.ex
+++ b/lib/contexted/utils.ex
@@ -17,6 +17,12 @@ defmodule Contexted.Utils do
   def get_config_contexts, do: get_from_config(:contexts, [])
 
   @doc """
+  Returns `context_options` option value from contexted config or `[]` if it's not set.
+  """
+  @spec get_config_context_options :: Keyword.t()
+  def get_config_context_options, do: get_from_config(:context_options, [])
+
+  @doc """
   Returns `exclude_paths` option value from contexted config or [] if it's not set.
   """
   @spec get_config_exclude_paths :: list(String.t())


### PR DESCRIPTION
First of all, thank you for this library - I had been considering building something similar myself, but now I don’t have to.

This pull request adds two pieces of functionality around the context boundary detection, with the goal of helping more gradual enforcement for existing projects which might have a lot of inter-context dependencies.  Both are configured via a new “context_options” key in the contested config.

First, add support for a `level` config.  If this key is set to :warn, the compiler will emit a warning instead a compile-time exception.

Second, add a way to configure “allowed” couplings via the `allow` config.  If a coupling is allowed, then no warning/exception will be triggered.  This key is a list of `{calling_context_module, [allowed_called_module, ...]}`.

The following example shows a configuration for two contexts where couplings trigger warnings rather than exceptions, and MyApp.Documents is explicitly permitted to call MyApp.Accounts.

```
config :contexted,
  contexts: [
    MyApp.Accounts,
    MyApp.Documents
  ],
  context_options: [
    level: :warn,
    allow: [
      {MyApp.Documents, [MyApp.Accounts]}
    ]
  ]
```